### PR TITLE
fix: add missing license on package publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "type": "git",
     "url": "https://github.com/rlespinasse/textlint-rule-link-title-case.git"
   },
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Fix the missing license information in [npm](https://www.npmjs.com/package/textlint-rule-link-title-case)

<img width="198" alt="none" src="https://github.com/user-attachments/assets/3e9f7839-69c9-48ce-9062-7ba9127ee97f" />
