### PR TITLE
build: use codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @rlespinasse

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       dependencies:
         patterns:
           - '*'
-    reviewers:
-      - 'rlespinasse'
     labels: []
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -20,6 +18,4 @@ updates:
       dependencies:
         patterns:
           - '*'
-    reviewers:
-      - 'rlespinasse'
     labels: []


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/